### PR TITLE
allow logging to file in json and text format

### DIFF
--- a/src/create.rs
+++ b/src/create.rs
@@ -3,7 +3,8 @@ use std::io::prelude::*;
 
 use crate::container::OCIContainer;
 
-pub fn create_container(id: Option<&str>, bundle: Option<&str>) {
+pub fn create_container(id: Option<&str>, bundle: Option<&str>, pidfile: Option<&str>) {
+
 	let container = OCIContainer::new(bundle.unwrap().to_string(), id.unwrap().to_string());
 	let mut path = crate::get_project_dir();
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,22 +1,61 @@
-use log::{set_logger, set_max_level, Level, LevelFilter, Metadata, Record};
-struct RunhLogger;
+use log::{set_boxed_logger, set_max_level, Level, LevelFilter, Metadata, Record};
+use std::fs::File;
+use std::io::Write;
+use std::sync::Mutex;
+use serde_json::to_string;
+use serde::Serialize;
+use chrono::Local;
 
-impl log::Log for RunhLogger {
+enum LogFormat {
+	TEXT,
+	JSON
+}
+
+#[derive(Serialize)]
+struct LogEntry {
+	level: String,
+	msg: String,
+	time: String
+}
+
+struct RunhLogger<W: Write + Send + 'static> {
+	log_file: Mutex<Option<W>>,
+	log_format: LogFormat
+}
+
+impl<W: Write + Send + 'static> log::Log for RunhLogger<W> {
 	fn enabled(&self, _metadata: &Metadata) -> bool {
 		true
 	}
 
 	fn log(&self, record: &Record) {
+		let mut file_lock = self.log_file.lock().unwrap();
 		if self.enabled(record.metadata()) {
-			self.print_level(record.level());
-			println!(" {}", record.args());
+			if let Some(file) = &mut *file_lock {
+				let message = match self.log_format {
+					LogFormat::TEXT => {
+						format!("[{}] {}", record.level(), record.args())
+					},
+					LogFormat::JSON => {
+						to_string(&LogEntry {
+							level: record.level().as_str().to_ascii_lowercase(),
+							msg: format!("{}", record.args()),
+							time: Local::now().to_rfc3339()
+						}).unwrap()
+					}
+				};
+				writeln!(file, "{}", message).unwrap();
+			} else {
+				self.print_level(record.level());
+				println!(" {}", record.args());
+			}
 		}
 	}
 
 	fn flush(&self) {}
 }
 
-impl RunhLogger {
+impl<W: Write + Send + 'static> RunhLogger<W> {
 	/// To improve the readability, every log level
 	/// get its own color. This helper function
 	/// prints the log level with its associated color.
@@ -41,8 +80,22 @@ impl RunhLogger {
 	}
 }
 
-pub fn init(log_level: Option<&str>) {
-	set_logger(&RunhLogger).expect("Can't initialize logger");
+pub fn init(log_path: Option<&str>, log_format: Option<&str>, log_level: Option<&str>) {
+
+	let log_file = log_path.map(|path| std::fs::File::create(path).expect("Could not create new log file!"));
+	let log_format = log_format.map_or(LogFormat::TEXT, |fmt| {
+		match fmt {
+			"json" => LogFormat::JSON,
+			_ => LogFormat::TEXT
+		}
+	});
+
+	let logger: RunhLogger<File> = RunhLogger {
+		log_file: Mutex::new(log_file),
+		log_format
+	};
+
+	set_boxed_logger(Box::new(logger)).expect("Can't initialize logger");
 	let max_level: LevelFilter = match log_level {
 		Some("error") => LevelFilter::Error,
 		Some("debug") => LevelFilter::Debug,
@@ -53,4 +106,7 @@ pub fn init(log_level: Option<&str>) {
 		_ => LevelFilter::Info,
 	};
 	set_max_level(max_level);
+
+	info!("Runh logger initialized!");
+
 }


### PR DESCRIPTION
This implements the command-line options --log and --log-format for logging to a file in JSON or text format. When no file path is given, the default (colored) text logger is used.