### PR TITLE
test RustyHermit container and not longer common containers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
     - name: Setup runh with Docker
       shell: sudo bash --noprofile --norc -eo pipefail {0}
       run: |
-        sed -i 's/{/{ "default-runtime": "runc", "runtimes": { "runh": { "path": "\/home\/runner\/.cargo\/bin\/runh", "runtimeArgs": ["-l", "debug", "--root", "\/run\/runh"] } },/g' /etc/docker/daemon.json
+        sed -i 's/{/{ "default-runtime": "runc", "runtimes": { "runh": { "path": "\/home\/runner\/.cargo\/bin\/runh", "runtimeArgs": ["-l", "debug", "--hermit-env", "\/run\/runh/hermit"] } },/g' /etc/docker/daemon.json
         >&2 cat /etc/docker/daemon.json
         systemctl restart docker || systemctl status docker
     - name: Check Docker runtime

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,6 @@ jobs:
       id: runh-crio-setup
       shell: sudo bash --noprofile --norc -eo pipefail {0}
       run: |
-        sed -i 's/default_runtime = "runc"/default_runtime = "runh"/g' /etc/crio/crio.conf
         sed -i 's/\[crio.runtime.runtimes.runc\]/\[crio.runtime.runtimes.runh\]\nruntime_path = "\/home\/runner\/.cargo\/bin\/runh"\nruntime_type = "oci"\nruntime_root = "\/run\/runh"\n\n\[crio.runtime.runtimes.runc\]/g' /etc/crio/crio.conf
         systemctl restart crio || systemctl status crio
         >&2 cat /etc/crio/crio.conf
@@ -114,7 +113,7 @@ jobs:
       if: ${{ always() && steps.runh-crio-setup.outcome == 'success' }}
       shell: sudo bash --noprofile --norc -eo pipefail {0}
       run: |
-         crictl runp /home/runner/pod.json > pod.id
+         crictl runp --runtime=runh /home/runner/pod.json > pod.id
          export PODID=$(cat pod.id)        
          crictl create $PODID /home/runner/container.json /home/runner/pod.json > container.id
          export CONTAINERID=$(cat container.id)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Install Qemu
+      run: |
+        apt-get update
+        apt-get install -y qemu-system-x86 qemu-system-x86-microvm
     - name: Install CRI-O
       shell: sudo bash --noprofile --norc -eo pipefail {0}
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,16 +38,18 @@ jobs:
         curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-${VERSION}-linux-amd64.tar.gz --output crictl-${VERSION}-linux-amd64.tar.gz
         sudo tar zxvf crictl-$VERSION-linux-amd64.tar.gz -C /usr/local/bin
         rm -f crictl-$VERSION-linux-amd64.tar.gz
-    - name: Pull Hermit environment
+    - name: Pull images
       run: |
         docker pull ghcr.io/hermitcore/hermit_env:latest
+        docker pull ghcr.io/hermitcore/rusty_demo:latest
+        sudo crictl pull ghcr.io/hermitcore/rusty_demo:latest
+    - name: Setup Hermit environment
+      run: |
         docker export $(docker create ghcr.io/hermitcore/hermit_env:latest) > hermit-env.tar
         sudo mkdir -p /run/runh/hermit
         sudo tar -xf hermit-env.tar -C /run/runh/hermit
-    - name: Pull container image
+    - name: Setup rootfs
       run: |
-        sudo crictl pull ghcr.io/hermitcore/rusty_demo:latest
-        docker pull ghcr.io/hermitcore/rusty_demo:latest
         docker export $(docker create ghcr.io/hermitcore/rusty_demo:latest) > runh-image.tar
         mkdir -p /home/runner/runh-image/rootfs
         tar -xf runh-image.tar -C /home/runner/runh-image/rootfs
@@ -84,7 +86,7 @@ jobs:
     - name: Setup runh with Docker
       shell: sudo bash --noprofile --norc -eo pipefail {0}
       run: |
-        sed -i 's/{/{ "default-runtime": "runc", "runtimes": { "runh": { "path": "\/home\/runner\/.cargo\/bin\/runh" } },/g' /etc/docker/daemon.json
+        sed -i 's/{/{ "default-runtime": "runc", "runtimes": { "runh": { "path": "\/home\/runner\/.cargo\/bin\/runh", "runtimeArgs": ["-l", "debug", "--hermit-env", "</run/runh/hermit",] } },/g' /etc/docker/daemon.json
         >&2 cat /etc/docker/daemon.json
         systemctl restart docker || systemctl status docker
     - name: Check Docker runtime

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
     - name: Setup runh with Docker
       shell: sudo bash --noprofile --norc -eo pipefail {0}
       run: |
-        sed -i 's/{/{ "default-runtime": "runc", "runtimes": { "runc": { "path": "\/usr\/sbin\/runc" }, "runh": { "path": "\/home\/runner\/.cargo\/bin\/runh", "runtimeArgs": ["-l", "debug", "--root", "\/run\/runh",] } },/g' /etc/docker/daemon.json
+        sed -i 's/{/{ "default-runtime": "runc", "runtimes": { "runc": { "path": "runc" }, "runh": { "path": "\/home\/runner\/.cargo\/bin\/runh", "runtimeArgs": ["-l", "debug", "--root", "\/run\/runh"] } },/g' /etc/docker/daemon.json
         >&2 cat /etc/docker/daemon.json
         systemctl restart docker || systemctl status docker
     - name: Check Docker runtime

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,9 +43,9 @@ jobs:
         docker pull ghcr.io/hermitcore/hermit_env:latest
         docker export $(docker create ghcr.io/hermitcore/hermit_env:latest) > hermit-env.tar
         mkdir -p hermit-env
-        tar -xf hermit-env.tar -C hermit-env
         sudo mkdir -p /run/runh
-        sudo ln -s $PWD/hermit-env /run/runh/hermit
+        sudo tar -xf hermit-env.tar -C /run/runh/hermit
+        sudo tree /run/runh/hermit
     - name: Pull container image
       run: |
         sudo crictl pull ghcr.io/hermitcore/rusty_demo:latest
@@ -103,7 +103,6 @@ jobs:
       run: |
         cd /home/runner/runh-image
         tree .
-        tree /run/runh/hermit
         runh --root /run/runh spec --bundle . --args /hermit/rusty_demo
         runh --root /run/runh -l debug create  --bundle . runh-container
         runh --root /run/runh -l debug start  runh-container

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,9 +38,7 @@ jobs:
       run: apt-get install cri-tools
     - name: Check CRI-O status
       shell: sudo bash --noprofile --norc -eo pipefail {0}
-      run: |
-        systemctl status crio
-        ls -la /etc/crio
+      run: systemctl status crio
     - name: Pull images
       run: |
         docker pull ghcr.io/hermitcore/hermit_env:latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,6 +98,8 @@ jobs:
         sed -i 's/\[crio.runtime.runtimes.runc\]/\[crio.runtime.runtimes.runh\]\nruntime_path = "\/home\/runner\/.cargo\/bin\/runh"\nruntime_type = "oci"\nruntime_root = "\/run\/runh"\n\n\[crio.runtime.runtimes.runc\]/g' /etc/crio/crio.conf
         systemctl restart crio || systemctl status crio
         >&2 cat /etc/crio/crio.conf
+    - name: Show crio.conf
+      run: cat /etc/crio/crio.conf
     - name: Test runh standalone
       shell: sudo bash --noprofile --norc -eo pipefail {0}
       if: ${{ always() && steps.runh-crio-setup.outcome == 'success' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/$VERSION/$OS/Release.key | gpg --dearmor -o /usr/share/keyrings/libcontainers-crio-archive-keyring.gpg
         apt-get update
         apt-get install -y cri-o cri-o-runc
-        crio config --default > /ect/crio/crio.conf
+        crio config --default
         systemctl start crio.service
     - name: Install crictl
       shell: sudo bash --noprofile --norc -eo pipefail {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,8 +99,6 @@ jobs:
         sed -i 's/\[crio.runtime.runtimes.runc\]/\[crio.runtime.runtimes.runh\]\nruntime_path = "\/home\/runner\/.cargo\/bin\/runh"\nruntime_type = "oci"\nruntime_root = "\/run\/runh"\n\n\[crio.runtime.runtimes.runc\]/g' /etc/crio/crio.conf
         systemctl restart crio || systemctl status crio
         >&2 cat /etc/crio/crio.conf
-    - name: Show crio.conf
-      run: cat /etc/crio/crio.conf
     - name: Test runh standalone
       shell: sudo bash --noprofile --norc -eo pipefail {0}
       if: ${{ always() && steps.runh-crio-setup.outcome == 'success' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,6 @@ jobs:
       run: |
         docker pull ghcr.io/hermitcore/hermit_env:latest
         docker export $(docker create ghcr.io/hermitcore/hermit_env:latest) > hermit-env.tar
-        mkdir -p hermit-env
         sudo mkdir -p /run/runh/hermit
         sudo tar -xf hermit-env.tar -C /run/runh/hermit
     - name: Pull container image
@@ -89,7 +88,6 @@ jobs:
         >&2 cat /etc/docker/daemon.json
         systemctl restart docker || systemctl status docker
     - name: Check Docker runtime
-      shell: sudo bash --noprofile --norc -eo pipefail {0}
       run: docker info|grep -i runtime
     - name: Set up runh with CRI-O
       id: runh-crio-setup

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
         curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/$VERSION/$OS/Release.key | gpg --dearmor -o /usr/share/keyrings/libcontainers-crio-archive-keyring.gpg
         apt-get update
         apt-get install -y cri-o cri-o-runc
+        crio config --default > /ect/crio/crio.conf
         systemctl start crio.service
     - name: Install crictl
       shell: sudo bash --noprofile --norc -eo pipefail {0}
@@ -39,7 +40,6 @@ jobs:
       shell: sudo bash --noprofile --norc -eo pipefail {0}
       run: |
         systemctl status crio
-        crio -d "" --config="" config > /ect/crio/crio.conf
         ls -la /etc/crio
     - name: Pull images
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,9 @@ jobs:
       run: apt-get install cri-tools
     - name: Check CRI-O status
       shell: sudo bash --noprofile --norc -eo pipefail {0}
-      run: systemctl status crio
+      run: |
+        systemctl status crio
+        ls -la /etc/crio
     - name: Pull images
       run: |
         docker pull ghcr.io/hermitcore/hermit_env:latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
         docker pull ghcr.io/hermitcore/hermit_env:latest
         docker export $(docker create ghcr.io/hermitcore/hermit_env:latest) > hermit-env.tar
         mkdir -p hermit-env
-        sudo mkdir -p /run/runh
+        sudo mkdir -p /run/runh/hermit
         sudo tar -xf hermit-env.tar -C /run/runh/hermit
         sudo tree /run/runh/hermit
     - name: Pull container image

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
     - name: Setup runh with Docker
       shell: sudo bash --noprofile --norc -eo pipefail {0}
       run: |
-        sed -i 's/{/{ "default-runtime": "runc", "runtimes": { "runh": { "path": "\/home\/runner\/.cargo\/bin\/runh", "runtimeArgs": ["-l", "debug", "--root", "<\/run\/runh",] } },/g' /etc/docker/daemon.json
+        sed -i 's/{/{ "default-runtime": "runc", "runtimes": { "runh": { "path": "\/home\/runner\/.cargo\/bin\/runh", "runtimeArgs": ["-l", "debug", "--root", "\/run\/runh",] } },/g' /etc/docker/daemon.json
         >&2 cat /etc/docker/daemon.json
         systemctl restart docker || systemctl status docker
     - name: Check Docker runtime

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,6 +95,7 @@ jobs:
       id: runh-crio-setup
       shell: sudo bash --noprofile --norc -eo pipefail {0}
       run: |
+        cat /etc/crio/crio.conf
         sed -i 's/default_runtime = "runc"/default_runtime = "runh"/g' /etc/crio/crio.conf
         sed -i 's/\[crio.runtime.runtimes\]/\[crio.runtime.runtimes\]\n\[crio.runtime.runtimes.runh\]\nruntime_path = "\/home\/runner\/.cargo\/bin\/runh"\nruntime_type = "oci"\nruntime_root = "\/run\/runh"/g' /etc/crio/crio.conf
         systemctl restart crio || systemctl status crio

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
         curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/$VERSION/$OS/Release.key | gpg --dearmor -o /usr/share/keyrings/libcontainers-crio-archive-keyring.gpg
         apt-get update
         apt-get install -y cri-o cri-o-runc
+        crio -d "" --config="" config > /ect/crio/crio.conf
         systemctl start crio.service
     - name: Install crictl
       shell: sudo bash --noprofile --norc -eo pipefail {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,17 +32,12 @@ jobs:
         apt-get update
         apt-get install -y cri-o cri-o-runc
         systemctl start crio.service
+    - name: Install crictl
+      shell: sudo bash --noprofile --norc -eo pipefail {0}
+      run: apt-get install cri-tools
     - name: Check CRI-O status
       shell: sudo bash --noprofile --norc -eo pipefail {0}
-      run: |
-        systemctl status crio
-        apt info cri-tools
-    - name: Install crictl
-      run: |
-        export VERSION="v1.23.0"
-        curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-${VERSION}-linux-amd64.tar.gz --output crictl-${VERSION}-linux-amd64.tar.gz
-        sudo tar zxvf crictl-$VERSION-linux-amd64.tar.gz -C /usr/local/bin
-        rm -f crictl-$VERSION-linux-amd64.tar.gz
+      run: systemctl status crio
     - name: Pull images
       run: |
         docker pull ghcr.io/hermitcore/hermit_env:latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
       run: |
         echo '{ "metadata": { "name": "hermit-sandbox", "namespace": "default", "attempt": 1, "uid": "hdishd83djaidwnduwk28bcsb" }, "log_directory": "/tmp", "linux": { } }' \
             > /home/runner/pod.json
-        echo '{ "metadata": { "name": "httpd" }, "image":{ "image": "ghcr.io/hermitcore/rusty_demo:latest" }, "log_path":"httpd.log", "linux": { } }' \
+        echo '{ "metadata": { "name": "rusty_demo" }, "image":{ "image": "ghcr.io/hermitcore/rusty_demo:latest" }, "log_path":"rusty_demo.log", "linux": { } }' \
             > /home/runner/container.json
     - uses: hecrj/setup-rust-action@v1
       with: 
@@ -100,7 +100,7 @@ jobs:
       if: ${{ always() && steps.runh-crio-setup.outcome == 'success' }}
       run: |
         cd /home/runner/runh-image
-        runh --root /run/runh spec --bundle . --args /hello
+        runh --root /run/runh spec --bundle . --args /rusty_demo
         runh --root /run/runh -l debug create  --bundle . runh-container
         runh --root /run/runh -l debug start  runh-container
         sleep 5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,22 +45,22 @@ jobs:
         rm -f crictl-$VERSION-linux-amd64.tar.gz
     - name: Pull Hermit environment
       run: |
-        docker export $(docker create docker.io/library/hello-world:latest) > hermit-env.tar
+        docker export $(docker create ghcr.io/hermitcore/rusty_demo:latest) > hermit-env.tar
         mkdir -p hermit-env
         tar -xf hermit-env.tar -C hermit-env
         sudo mkdir -p /run/runh
         sudo ln -s $PWD/hermit-env /run/runh/hermit
     - name: Pull container image
       run: |
-        sudo crictl pull docker.io/library/hello-world:latest
-        docker export $(docker create hello-world:latest) > runh-image.tar
+        sudo crictl pull ghcr.io/hermitcore/rusty_demo:latest
+        docker export $(docker create rusty_demo:latest) > runh-image.tar
         mkdir -p /home/runner/runh-image/rootfs
         tar -xf runh-image.tar -C /home/runner/runh-image/rootfs
     - name: Create CRI configurations
       run: |
         echo '{ "metadata": { "name": "hermit-sandbox", "namespace": "default", "attempt": 1, "uid": "hdishd83djaidwnduwk28bcsb" }, "log_directory": "/tmp", "linux": { } }' \
             > /home/runner/pod.json
-        echo '{ "metadata": { "name": "httpd" }, "image":{ "image": "docker.io/library/hello-world:latest" }, "log_path":"httpd.log", "linux": { } }' \
+        echo '{ "metadata": { "name": "httpd" }, "image":{ "image": "ghcr.io/hermitcore/rusty_demo:latest" }, "log_path":"httpd.log", "linux": { } }' \
             > /home/runner/container.json
     - uses: hecrj/setup-rust-action@v1
       with: 
@@ -129,7 +129,7 @@ jobs:
       shell: sudo bash --noprofile --norc -eo pipefail {0}
       if: ${{ always() && steps.runh-crio-setup.outcome == 'success' }}
       run: |
-         docker run --runtime=runh -it -d -p 9975:9975 docker.io/library/hello-world:latest > container.id
+         docker run --runtime=runh -it -d -p 9975:9975 ghcr.io/hermitcore/rusty_demo:latest > container.id
          export CONTAINERID=$(cat container.id)
          sleep 2
          docker logs $CONTAINERID

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,6 @@ jobs:
         curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/$VERSION/$OS/Release.key | gpg --dearmor -o /usr/share/keyrings/libcontainers-crio-archive-keyring.gpg
         apt-get update
         apt-get install -y cri-o cri-o-runc
-        crio -d "" --config="" config > /ect/crio/crio.conf
         systemctl start crio.service
     - name: Install crictl
       shell: sudo bash --noprofile --norc -eo pipefail {0}
@@ -40,6 +39,7 @@ jobs:
       shell: sudo bash --noprofile --norc -eo pipefail {0}
       run: |
         systemctl status crio
+        crio -d "" --config="" config > /ect/crio/crio.conf
         ls -la /etc/crio
     - name: Pull images
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       run: |
         export DEBIAN_FRONTEND=noninteractive
         apt-get update
-        apt-get install -y curl gnupg tree
+        apt-get install -y curl gnupg tree conntrack
         export OS=xUbuntu_20.04
         export VERSION=1.23
         echo "deb [signed-by=/usr/share/keyrings/libcontainers-archive-keyring.gpg] https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/$OS/ /" > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
@@ -31,7 +31,6 @@ jobs:
         curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/$VERSION/$OS/Release.key | gpg --dearmor -o /usr/share/keyrings/libcontainers-crio-archive-keyring.gpg
         apt-get update
         apt-get install -y cri-o cri-o-runc
-        ls -la /usr/bin/runc
         systemctl start crio.service
     - name: Install crictl
       shell: sudo bash --noprofile --norc -eo pipefail {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
 
     steps:
     - name: Install Qemu
+      shell: sudo bash --noprofile --norc -eo pipefail {0}
       run: |
         apt-get update
         apt-get install -y qemu-system-x86 qemu-system-x86-microvm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
     - name: Setup runh with Docker
       shell: sudo bash --noprofile --norc -eo pipefail {0}
       run: |
-        sed -i 's/{/{ "default-runtime": "runc", "runtimes": { "runh": { "path": "\/home\/runner\/.cargo\/bin\/runh", "runtimeArgs": ["-l", "debug", "--hermit-env", "</run/runh/hermit",] } },/g' /etc/docker/daemon.json
+        sed -i 's/{/{ "default-runtime": "runc", "runtimes": { "runh": { "path": "\/home\/runner\/.cargo\/bin\/runh", "runtimeArgs": ["-l", "debug", "--root", "<\/run\/runh",] } },/g' /etc/docker/daemon.json
         >&2 cat /etc/docker/daemon.json
         systemctl restart docker || systemctl status docker
     - name: Check Docker runtime

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
     - name: Setup runh with Docker
       shell: sudo bash --noprofile --norc -eo pipefail {0}
       run: |
-        sed -i 's/{/{ "default-runtime": "runc", "runtimes": { "runh": { "path": "\/home\/runner\/.cargo\/bin\/runh", "runtimeArgs": ["-l", "debug", "--hermit-env", "\/run\/runh/hermit"] } },/g' /etc/docker/daemon.json
+        sed -i 's/{/{ "default-runtime": "runc", "runtimes": { "runh": { "path": "\/home\/runner\/.cargo\/bin\/runh", "runtimeArgs": ["-l", "debug", "--hermit-env", "\/run\/runh\/hermit"] } },/g' /etc/docker/daemon.json
         >&2 cat /etc/docker/daemon.json
         systemctl restart docker || systemctl status docker
     - name: Check Docker runtime

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,7 @@ jobs:
         rm -f crictl-$VERSION-linux-amd64.tar.gz
     - name: Pull Hermit environment
       run: |
+        docker pull ghcr.io/hermitcore/hermit_env:latest
         docker export $(docker create ghcr.io/hermitcore/hermit_env:latest) > hermit-env.tar
         mkdir -p hermit-env
         tar -xf hermit-env.tar -C hermit-env
@@ -48,6 +49,7 @@ jobs:
     - name: Pull container image
       run: |
         sudo crictl pull ghcr.io/hermitcore/rusty_demo:latest
+        docker pull create ghcr.io/hermitcore/rusty_demo:latest
         docker export $(docker create ghcr.io/hermitcore/rusty_demo:latest) > runh-image.tar
         mkdir -p /home/runner/runh-image/rootfs
         tar -xf runh-image.tar -C /home/runner/runh-image/rootfs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Pull container image
       run: |
         sudo crictl pull ghcr.io/hermitcore/rusty_demo:latest
-        docker pull create ghcr.io/hermitcore/rusty_demo:latest
+        docker pull ghcr.io/hermitcore/rusty_demo:latest
         docker export $(docker create ghcr.io/hermitcore/rusty_demo:latest) > runh-image.tar
         mkdir -p /home/runner/runh-image/rootfs
         tar -xf runh-image.tar -C /home/runner/runh-image/rootfs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
     - name: Setup runh with Docker
       shell: sudo bash --noprofile --norc -eo pipefail {0}
       run: |
-        sed -i 's/{/{ "default-runtime": "runc", "runtimes": { "runh": { "path": "\/home\/runner\/.cargo\/bin\/runh", "runtimeArgs": ["-l", "debug", "--root", "\/run\/runh",] } },/g' /etc/docker/daemon.json
+        sed -i 's/{/{ "default-runtime": "runc", "runtimes": { "runc": { "path": "\/usr\/sbin\/runc" }, "runh": { "path": "\/home\/runner\/.cargo\/bin\/runh", "runtimeArgs": ["-l", "debug", "--root", "\/run\/runh",] } },/g' /etc/docker/daemon.json
         >&2 cat /etc/docker/daemon.json
         systemctl restart docker || systemctl status docker
     - name: Check Docker runtime

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,11 +16,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Install Qemu
-      shell: sudo bash --noprofile --norc -eo pipefail {0}
-      run: |
-        apt-get update
-        apt-get install -y qemu-system-x86 qemu-system-x86-microvm
     - name: Install CRI-O
       shell: sudo bash --noprofile --norc -eo pipefail {0}
       run: |
@@ -45,7 +40,7 @@ jobs:
         rm -f crictl-$VERSION-linux-amd64.tar.gz
     - name: Pull Hermit environment
       run: |
-        docker export $(docker create ghcr.io/hermitcore/rusty_demo:latest) > hermit-env.tar
+        docker export $(docker create ghcr.io/hermitcore/hermit_env:latest) > hermit-env.tar
         mkdir -p hermit-env
         tar -xf hermit-env.tar -C hermit-env
         sudo mkdir -p /run/runh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,6 +101,7 @@ jobs:
       run: |
         cd /home/runner/runh-image
         tree .
+        tree /run/runh/hermit
         runh --root /run/runh spec --bundle . --args /hermit/rusty_demo
         runh --root /run/runh -l debug create  --bundle . runh-container
         runh --root /run/runh -l debug start  runh-container

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/$VERSION/$OS/Release.key | gpg --dearmor -o /usr/share/keyrings/libcontainers-crio-archive-keyring.gpg
         apt-get update
         apt-get install -y cri-o cri-o-runc
-        crio config --default
+        crio config --default 1> /etc/crio/crio.conf
         systemctl start crio.service
     - name: Install crictl
       shell: sudo bash --noprofile --norc -eo pipefail {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,6 +88,9 @@ jobs:
         sed -i 's/{/{ "default-runtime": "runc", "runtimes": { "runh": { "path": "\/home\/runner\/.cargo\/bin\/runh" } },/g' /etc/docker/daemon.json
         >&2 cat /etc/docker/daemon.json
         systemctl restart docker || systemctl status docker
+    - name: Check Docker runtime
+      shell: sudo bash --noprofile --norc -eo pipefail {0}
+      run: docker info|grep -i runtime
     - name: Set up runh with CRI-O
       id: runh-crio-setup
       shell: sudo bash --noprofile --norc -eo pipefail {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,9 +95,8 @@ jobs:
       id: runh-crio-setup
       shell: sudo bash --noprofile --norc -eo pipefail {0}
       run: |
-        cat /etc/crio/crio.conf
         sed -i 's/default_runtime = "runc"/default_runtime = "runh"/g' /etc/crio/crio.conf
-        sed -i 's/\[crio.runtime.runtimes\]/\[crio.runtime.runtimes\]\n\[crio.runtime.runtimes.runh\]\nruntime_path = "\/home\/runner\/.cargo\/bin\/runh"\nruntime_type = "oci"\nruntime_root = "\/run\/runh"/g' /etc/crio/crio.conf
+        sed -i 's/\[crio.runtime.runtimes.runc\]/\[crio.runtime.runtimes.runh\]\nruntime_path = "\/home\/runner\/.cargo\/bin\/runh"\nruntime_type = "oci"\nruntime_root = "\/run\/runh"\n\n\[crio.runtime.runtimes.runc\]/g' /etc/crio/crio.conf
         systemctl restart crio || systemctl status crio
         >&2 cat /etc/crio/crio.conf
     - name: Test runh standalone

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
         curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/$VERSION/$OS/Release.key | gpg --dearmor -o /usr/share/keyrings/libcontainers-crio-archive-keyring.gpg
         apt-get update
         apt-get install -y cri-o cri-o-runc
+        ln -s /usr/lib/cri-o-runc/sbin/runc /usr/bin/runc
         systemctl start crio.service
     - name: Install crictl
       shell: sudo bash --noprofile --norc -eo pipefail {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/$VERSION/$OS/Release.key | gpg --dearmor -o /usr/share/keyrings/libcontainers-crio-archive-keyring.gpg
         apt-get update
         apt-get install -y cri-o cri-o-runc
-        ln -s /usr/lib/cri-o-runc/sbin/runc /usr/bin/runc
+        ls -la /usr/bin/runc
         systemctl start crio.service
     - name: Install crictl
       shell: sudo bash --noprofile --norc -eo pipefail {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
     - name: Setup runh with Docker
       shell: sudo bash --noprofile --norc -eo pipefail {0}
       run: |
-        sed -i 's/{/{ "default-runtime": "runc", "runtimes": { "runc": { "path": "runc" }, "runh": { "path": "\/home\/runner\/.cargo\/bin\/runh", "runtimeArgs": ["-l", "debug", "--root", "\/run\/runh"] } },/g' /etc/docker/daemon.json
+        sed -i 's/{/{ "default-runtime": "runc", "runtimes": { "runh": { "path": "\/home\/runner\/.cargo\/bin\/runh", "runtimeArgs": ["-l", "debug", "--root", "\/run\/runh"] } },/g' /etc/docker/daemon.json
         >&2 cat /etc/docker/daemon.json
         systemctl restart docker || systemctl status docker
     - name: Check Docker runtime

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,12 @@ jobs:
         curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/$VERSION/$OS/Release.key | gpg --dearmor -o /usr/share/keyrings/libcontainers-crio-archive-keyring.gpg
         apt-get update
         apt-get install -y cri-o cri-o-runc
-        systemctl start crio
+        systemctl start crio.service
+    - name: Check CRI-O status
+      shell: sudo bash --noprofile --norc -eo pipefail {0}
+      run: |
+        systemctl status crio
+        apt info cri-tools
     - name: Install crictl
       run: |
         export VERSION="v1.23.0"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       run: |
         export DEBIAN_FRONTEND=noninteractive
         apt-get update
-        apt-get install -y curl gnupg
+        apt-get install -y curl gnupg tree
         export OS=xUbuntu_20.04
         export VERSION=1.23
         echo "deb [signed-by=/usr/share/keyrings/libcontainers-archive-keyring.gpg] https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/$OS/ /" > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
@@ -100,7 +100,8 @@ jobs:
       if: ${{ always() && steps.runh-crio-setup.outcome == 'success' }}
       run: |
         cd /home/runner/runh-image
-        runh --root /run/runh spec --bundle . --args /rusty_demo
+        tree .
+        runh --root /run/runh spec --bundle . --args /hermit/rusty_demo
         runh --root /run/runh -l debug create  --bundle . runh-container
         runh --root /run/runh -l debug start  runh-container
         sleep 5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Pull container image
       run: |
         sudo crictl pull ghcr.io/hermitcore/rusty_demo:latest
-        docker export $(docker create rusty_demo:latest) > runh-image.tar
+        docker export $(docker create ghcr.io/hermitcore/rusty_demo:latest) > runh-image.tar
         mkdir -p /home/runner/runh-image/rootfs
         tar -xf runh-image.tar -C /home/runner/runh-image/rootfs
     - name: Create CRI configurations

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,6 @@ jobs:
         mkdir -p hermit-env
         sudo mkdir -p /run/runh/hermit
         sudo tar -xf hermit-env.tar -C /run/runh/hermit
-        sudo tree /run/runh/hermit
     - name: Pull container image
       run: |
         sudo crictl pull ghcr.io/hermitcore/rusty_demo:latest

--- a/src/create.rs
+++ b/src/create.rs
@@ -189,6 +189,7 @@ pub fn create_container(
 			overlay_upperdir.as_os_str().to_str().unwrap(),
 			overlay_workdir.as_os_str().to_str().unwrap()
 		);
+		debug!("Mount with mergedir {} and datastr {}", overlay_mergeddir.to_str().unwrap_or_default(), datastr);
 		nix::mount::mount::<str, PathBuf, str, str>(
 			Some("overlay"),
 			&overlay_mergeddir,

--- a/src/create.rs
+++ b/src/create.rs
@@ -189,7 +189,6 @@ pub fn create_container(
 			overlay_upperdir.as_os_str().to_str().unwrap(),
 			overlay_workdir.as_os_str().to_str().unwrap()
 		);
-		debug!("Mount with mergedir {} and datastr {}", overlay_mergeddir.to_str().unwrap_or_default(), datastr);
 		nix::mount::mount::<str, PathBuf, str, str>(
 			Some("overlay"),
 			&overlay_mergeddir,

--- a/src/devices.rs
+++ b/src/devices.rs
@@ -196,7 +196,13 @@ pub fn create_tun(rootfs: &PathBuf, uid: Uid, gid: Gid) {
 }
 
 pub fn mount_hermit_devices(rootfs: &PathBuf) {
-	mount_device(rootfs, &PathBuf::from("/dev/kvm"), 10, 232);
+	let kvm: u32 = std::env::var("RUNH_KVM")
+		.unwrap_or("0".to_string())
+		.parse()
+		.expect("RUNH_KVM was not an unsigned integer!");
+	if kvm > 0 {
+		mount_device(rootfs, &PathBuf::from("/dev/kvm"), 10, 232);
+	}
 	mount_device(rootfs, &PathBuf::from("/dev/vhost-net"), 10, 238);
 }
 

--- a/src/hermit.rs
+++ b/src/hermit.rs
@@ -59,15 +59,28 @@ pub fn get_qemu_args(
 		kernel,
 		"-initrd",
 		app,
-		"-cpu",
-		"host",
 	]
 	.iter()
 	.map(|s| s.to_string())
 	.collect();
 
 	if kvm {
-		exec_args.append(&mut vec!["--enable-kvm"].iter().map(|s| s.to_string()).collect());
+		exec_args.append(
+			&mut vec!["--enable-kvm", "-cpu", "host"]
+				.iter()
+				.map(|s| s.to_string())
+				.collect(),
+		);
+	} else {
+		exec_args.append(
+			&mut vec![
+				"-cpu",
+				"qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand",
+			]
+			.iter()
+			.map(|s| s.to_string())
+			.collect(),
+		);
 	}
 
 	if micro_vm {

--- a/src/hermit.rs
+++ b/src/hermit.rs
@@ -43,10 +43,10 @@ pub fn get_qemu_args(
 	netconf: &Option<network::HermitNetworkConfig>,
 	app_args: &Vec<String>,
 	micro_vm: bool,
+	kvm: bool,
 ) -> Vec<String> {
 	let mut exec_args: Vec<String> = vec![
 		"qemu-system-x86_64",
-		"-enable-kvm",
 		"-display",
 		"none",
 		"-smp",
@@ -65,6 +65,10 @@ pub fn get_qemu_args(
 	.iter()
 	.map(|s| s.to_string())
 	.collect();
+
+	if kvm {
+		exec_args.append(&mut vec!["--enable-kvm"].iter().map(|s| s.to_string()).collect());
+	}
 
 	if micro_vm {
 		exec_args.append(

--- a/src/init.rs
+++ b/src/init.rs
@@ -654,6 +654,14 @@ fn init_stage(args: SetupArgs) -> isize {
 					.to_owned();
 				let kernel_path = app_root.join("rusty-loader");
 				let kernel = kernel_path.as_os_str().to_str().unwrap();
+				let kvm: u32 = env::var("RUNH_KVM")
+					.unwrap_or("0".to_string())
+					.parse()
+					.expect("RUNH_KVM was not an unsigned integer!");
+				let micro_vm: u32 = env::var("RUNH_MICRO_VM")
+					.unwrap_or("1".to_string())
+					.parse()
+					.expect("RUNH_MICRO_VM was not an unsigned integer!");
 				hermit::get_qemu_args(
 					kernel,
 					app,
@@ -666,7 +674,8 @@ fn init_stage(args: SetupArgs) -> isize {
 						.args()
 						.as_ref()
 						.unwrap(),
-					true,
+					micro_vm > 0,
+					kvm > 0,
 				)
 			} else {
 				args.config


### PR DESCRIPTION
Test were extended to use RustyHermit container. Containers published under https://github.com/orgs/hermitcore/packages are used for this purpose.

GitHub Actions do not support KVM. Therefore, the environment variable `RUNH_KVM` was introduced to enable/disable the support of KVM. To support KVM, the variable must be set to one. In addition, with the variable `RUNH_MICRO_VM` the support of micro VMs (https://qemu.readthedocs.io/en/latest/system/i386/microvm.html) can be enabled/disabled.