### PR TITLE
Bump rtnetlink from 0.8.1 to 0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -910,9 +910,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-core"
-version = "0.2.4"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac48279d5062bdf175bdbcb6b58ff1d6b0ecd54b951f7a0ff4bc0550fe903ccb"
+checksum = "345b8ab5bd4e71a2986663e88c56856699d060e78e152e6e9d7966fcd5491297"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -922,9 +922,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76aed5d3b6e3929713bf1e1334a11fd65180b6d9f5d7c8572664c48b122604f8"
+checksum = "733ea73609acfd7fa7ddadfb7bf709b0471668c456ad9513685af543a06342b2"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -936,9 +936,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-utils"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fcfb6f758b66e964b2339596d94078218d96aad5b32003e8e2a1d23c27a6784"
+checksum = "25af9cf0dc55498b7bd94a1508af7a78706aa0ab715a73c5169273e03c84845e"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -948,9 +948,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-proto"
-version = "0.7.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd06e90449ae973fe3888c1ff85949604ef5189b4ac9a2ae39518da1e00762d"
+checksum = "ef8785b8141e8432aa45fceb922a7e876d7da3fad37fa7e7ec702ace3aa0826b"
 dependencies = [
  "bytes",
  "futures",
@@ -958,15 +958,15 @@ dependencies = [
  "netlink-packet-core",
  "netlink-sys",
  "tokio",
- "tokio-util",
 ]
 
 [[package]]
 name = "netlink-sys"
-version = "0.7.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f48ea34ea0678719815c3753155067212f853ad2d8ef4a49167bae7f7c254188"
+checksum = "3e4c9f9547a08241bee7b6558b9b98e1f290d187de8b7cfca2bbb4937bcaa8f8"
 dependencies = [
+ "bytes",
  "futures",
  "libc",
  "log",
@@ -1337,9 +1337,9 @@ checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
 
 [[package]]
 name = "rtnetlink"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9a6200d18ec1acfc218ce71363dcc9b6075f399220f903fdfeacd476a876ef"
+checksum = "6f54290e54521dac3de4149d83ddf9f62a359b3cc93bcb494a794a41e6f4744b"
 dependencies = [
  "futures",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ command-fds = "0.2"
 capctl = "0.2"
 path-clean = "0.1.0"
 procfs = "0.12.0"
-rtnetlink = "0.8.1"
+rtnetlink = "0.9.1"
 
 [dependencies.goblin]
 version = "0.5.1"

--- a/src/network.rs
+++ b/src/network.rs
@@ -42,7 +42,7 @@ pub async fn set_lo_up() -> Result<(), rtnetlink::Error> {
 	let mut links = handle
 		.link()
 		.get()
-		.set_name_filter("lo".to_string())
+		.match_name("lo".to_string())
 		.execute();
 	if let Some(link) = links.try_next().await? {
 		handle.link().set(link.header.index).up().execute().await?
@@ -122,7 +122,7 @@ pub async fn create_tap(
 	let mut links = handle
 		.link()
 		.get()
-		.set_name_filter("tap100".to_string())
+		.match_name("tap100".to_string())
 		.execute();
 	let read_interface = if links.try_next().await?.is_none() {
 		do_init = true;

--- a/src/network.rs
+++ b/src/network.rs
@@ -39,11 +39,7 @@ impl Error for HermitNetworkError {
 pub async fn set_lo_up() -> Result<(), rtnetlink::Error> {
 	let (connection, handle, _) = rtnetlink::new_connection().unwrap();
 	tokio::spawn(connection);
-	let mut links = handle
-		.link()
-		.get()
-		.match_name("lo".to_string())
-		.execute();
+	let mut links = handle.link().get().match_name("lo".to_string()).execute();
 	if let Some(link) = links.try_next().await? {
 		handle.link().set(link.header.index).up().execute().await?
 	} else {


### PR DESCRIPTION
using the new interface match_name instead of set_name_filter