### PR TITLE
Rework networking setup to create a macvtap via rtnetlink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1289,8 +1289,7 @@ checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 [[package]]
 name = "rtnetlink"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f1cfa18f8cebe685373a2697915d7e0db3b4554918bba118385e0f71f258a7"
+source = "git+https://github.com/rust-netlink/rtnetlink.git#63f083c0be51414e517cfc2412cc35a4b3dd1d2b"
 dependencies = [
  "futures",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ nix = "0.25"
 oci-spec = "0.5"
 path-clean = "0.1"
 procfs = { version = "0.14", default-features = false }
-rtnetlink = "0.11"
+rtnetlink = { git = "https://github.com/rust-netlink/rtnetlink.git" }
 serde_json = "1.0"
 serde = "1.0"
 time = { version = "0.3", features = ["formatting"] }

--- a/roadmap.md
+++ b/roadmap.md
@@ -57,7 +57,6 @@
 # Issues
 - Networking
   - works rather inconsistent (might be because of RustyHermit network code)
-  - relies on the IP command instead of using an internal netlink library
   - network namespace is not reset when restarting a Kubernetes Pod -> usage of dummy device in network.rs
   - when a Hermit-Container runs in a pod, other containers in this pod likely can't access the network
     - running two Hermit-Containers in one pod should not be possible
@@ -81,7 +80,7 @@
 - Container images
   - when `runh` detects a Hermit-App, it does not check any other files in the image. By providing a file named `qemu-system-x86_64` in the image, a Hermit-Image can run arbitrary code in a container (in the same way, Linux images can). This might be a feature (e.g. to allow users to
   package their own version of QEMU) or a security issue (when `runh` makes assumptions based on the fact that only the QEMU VM will run in any given Hermit container)
-  - Are their licensing issues with providing the Hermit Environment base image (containing Ubuntu + QEMU files) on some RWTH registry?
+  - Are there licensing issues with providing the Hermit Environment base image (containing Ubuntu + QEMU files) on some RWTH registry?
 
 
 # Missing features:

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,8 +1,5 @@
 pub const INIT_REQ_PRESTART_HOOKS: u8 = 0x10;
 pub const CREATE_ACK_PRESTART_HOOKS: u8 = 0x11;
 pub const INIT_READY_TO_EXECV: u8 = 0xAA;
-pub const INIT_REQ_SAVE_NETWORK_SETUP: u8 = 0x20;
-pub const INIT_REQ_SKIP_NETWORK_SETUP: u8 = 0x22;
-pub const CREATE_ACK_NETWORK_SETUP: u8 = 0x21;
 
 pub const OCI_STATE_VERSION: &str = "1.0.2";

--- a/src/create.rs
+++ b/src/create.rs
@@ -424,56 +424,6 @@ pub fn create_container(
 		.write_all(&[crate::consts::CREATE_ACK_PRESTART_HOOKS])
 		.expect("Unable to write to init-pipe!");
 
-	//Save hermit network setup
-	if is_hermit_container {
-		let mut sig_buffer = [0u8];
-
-		init_pipe
-			.read_exact(&mut sig_buffer)
-			.expect("Could not read from init pipe!");
-		match sig_buffer[0] {
-			crate::consts::INIT_REQ_SKIP_NETWORK_SETUP => {
-				init_pipe
-					.write_all(&[crate::consts::CREATE_ACK_NETWORK_SETUP])
-					.expect("Unable to write to init-pipe!");
-			}
-			crate::consts::INIT_REQ_SAVE_NETWORK_SETUP => {
-				let mut size_buffer = [0u8; std::mem::size_of::<usize>()];
-				init_pipe
-					.read_exact(&mut size_buffer)
-					.expect("Could not read message size from init-pipe!");
-				let message_size = usize::from_le_bytes(size_buffer);
-				debug!("Network setup data length: {}", message_size);
-
-				let mut network_setup_buffer = vec![0; message_size as usize];
-				init_pipe
-					.read_exact(&mut network_setup_buffer)
-					.expect("Could not read bundle rootfs path from init pipe!");
-				let network_setup = String::from_utf8(network_setup_buffer)
-					.expect("Could not parse bundle rootfs path as string!");
-				debug!("read network setup from init_pipe: {}", network_setup);
-
-				let mut network_setup_file =
-					std::fs::File::create(container_dir.join("hermit_network.json"))
-						.expect("Could not create hermit network file!");
-				write!(network_setup_file, "{}", network_setup)
-					.expect("Could not write to hermit network file!");
-
-				init_pipe
-					.write_all(&[crate::consts::CREATE_ACK_NETWORK_SETUP])
-					.expect("Unable to write to init-pipe!");
-			}
-			_ => {
-				panic!(
-					"Received invalid signal from runh init! Expected {:x} or {:x}, got {:x}",
-					crate::consts::INIT_REQ_SKIP_NETWORK_SETUP,
-					crate::consts::INIT_REQ_SAVE_NETWORK_SETUP,
-					sig_buffer[0]
-				);
-			}
-		}
-	}
-
 	//Waiting for init
 	debug!("Waiting for runh init to get ready to execv!");
 

--- a/src/create.rs
+++ b/src/create.rs
@@ -197,7 +197,7 @@ pub fn create_container(
 			nix::mount::MsFlags::empty(),
 			Some(datastr.as_str()),
 		)
-		.unwrap_or_else(|_| panic!("Could not create overlay-fs at {:?}", overlay_root));
+		.unwrap_or_else(|err| panic!("Could not create overlay-fs at {:?}: {}", overlay_root, err));
 		rootfs_path_abs = std::fs::canonicalize(overlay_mergeddir).unwrap();
 	}
 

--- a/src/create.rs
+++ b/src/create.rs
@@ -432,6 +432,7 @@ pub fn create_container(
 		panic!("Could not read from init-pipe! Init probably died: {}", x);
 	} else if sig_buffer[0] == crate::consts::INIT_READY_TO_EXECV {
 		info!("Runh init ran successfully and is now ready to execv. Waiting for log pipe to close...");
+		log_forwarder.join().expect("Log forwarder did panic!");
 	} else {
 		panic!("Received invalid signal from runh init!");
 	}

--- a/src/hermit.rs
+++ b/src/hermit.rs
@@ -44,6 +44,7 @@ pub fn get_qemu_args(
 	app_args: &[String],
 	micro_vm: bool,
 	kvm: bool,
+	tap_fd: &Option<i32>,
 ) -> Vec<String> {
 	let mut exec_args: Vec<String> = vec![
 		"qemu-system-x86_64",
@@ -103,7 +104,7 @@ pub fn get_qemu_args(
 
 	if let Some(network_config) = netconf.as_ref() {
 		exec_args.push("-netdev".to_string());
-		exec_args.push("tap,id=net0,ifname=tap100,script=no,downscript=no".to_string());
+		exec_args.push(format!("tap,id=net0,fd={}", tap_fd.unwrap()));
 		exec_args.push("-device".to_string());
 		exec_args.push(if micro_vm {
 			format!("virtio-net-device,netdev=net0,mac={}", network_config.mac)

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,9 +1,9 @@
 use futures::TryStreamExt;
 use nix::sys::stat::SFlag;
-use rtnetlink::packet::{address, link, route, ErrorMessage, MACVLAN_MODE_BRIDGE};
+use rtnetlink::packet::{address, link, route, ErrorMessage, MACVLAN_MODE_PASSTHRU};
 use rtnetlink::Error::NetlinkError;
 use std::path::PathBuf;
-use std::{error::Error, fmt, net::Ipv4Addr, process::Stdio};
+use std::{error::Error, fmt, net::Ipv4Addr};
 
 #[derive(Debug)]
 struct HermitNetworkError {
@@ -39,63 +39,15 @@ impl Error for HermitNetworkError {
 
 pub async fn set_lo_up() -> Result<(), rtnetlink::Error> {
 	let (connection, handle, _) = rtnetlink::new_connection().unwrap();
-	tokio::spawn(connection);
+	let _ = tokio::spawn(connection);
 	let mut links = handle.link().get().match_name("lo".to_string()).execute();
 	if let Some(link) = links.try_next().await? {
 		handle.link().set(link.header.index).up().execute().await?
 	} else {
 		panic!("Link lo not found!");
 	}
+
 	Ok(())
-}
-
-// pub fn undo_tap_creation(config: &HermitNetworkConfig) -> Result<(), Box<dyn std::error::Error>> {
-// 	let _ = run_command("ip", vec!["tuntap", "del", "tap100", "mode", "tap"]);
-// 	let _ = run_command("ip", vec!["link", "delete", "br0"]);
-// 	let _ = run_command("ip", vec!["link", "delete", "dummy0"]);
-// 	let _ = run_command(
-// 		"ip",
-// 		vec!["link", "set", "eth0", "address", config.mac.as_str()],
-// 	);
-// 	let _ = run_command(
-// 		"ip",
-// 		vec![
-// 			"addr",
-// 			"add",
-// 			format!(
-// 				"{}/{}",
-// 				config.ip.to_string(),
-// 				u32::from(config.mask).trailing_zeros()
-// 			)
-// 			.as_str(),
-// 			"dev",
-// 			"eth0",
-// 		],
-// 	);
-// 	Ok(())
-// }
-
-fn run_command(command: &str, args: Vec<&str>) -> Result<String, Box<dyn std::error::Error>> {
-	info!("Running command {} with args {}", command, args.join(" "));
-	let ret = std::process::Command::new(command)
-		.args(&args)
-		.stdout(Stdio::piped())
-		.stderr(Stdio::piped())
-		.spawn()?
-		.wait_with_output()?;
-	let stderr = String::from_utf8(ret.stderr)?;
-	if !ret.status.success() {
-		return Err(Box::new(HermitNetworkError::from(format!(
-			"Command {} with args {} failed! Exit code {}, stderr: {}",
-			command,
-			args.join(" "),
-			ret.status,
-			stderr
-		))));
-	}
-	let output = String::from_utf8(ret.stdout)?;
-	debug!("Command {} produced output {}", command, output);
-	Ok(output)
 }
 
 /**
@@ -103,153 +55,168 @@ fn run_command(command: &str, args: Vec<&str>) -> Result<String, Box<dyn std::er
  https://github.com/nabla-containers/runnc/blob/46ededdd75a03cecf05936a1a45d5d0096a2b117/nabla-lib/network/network_linux.go
 */
 pub async fn create_tap() -> Result<HermitNetworkConfig, Box<dyn std::error::Error>> {
-	//FIXME: This is extremely ugly
-	let mut do_init = false;
-
-	let _ = run_command(
-		//Debugging
-		"ip",
-		vec!["addr"],
-	);
-
 	let (connection, handle, _) = rtnetlink::new_connection()?;
-	tokio::spawn(connection);
-	let mut links = handle
+	let _ = tokio::spawn(connection);
+
+	// Check for an existing tap device
+	let mut tap_link_req = handle
 		.link()
 		.get()
-		.match_name("tap100".to_string())
+		.match_name("macvtap0".to_string())
 		.execute();
 
-	let read_interface = match links.try_next().await {
+	let do_init = match tap_link_req.try_next().await {
 		Ok(Some(_)) => {
-			warn!("Tap device already exists in current network namespace. Trying to read configuration from dummy device...");
-			"dummy0"
+			warn!("Tap device already exists in current network namespace. Trying to read configuration from eth0 / macvtap0 device...");
+			false
 		}
 		Ok(None) => {
 			warn!("Tap device exists in namespace but cannot be read. Trying to re-do setup...");
-			do_init = true;
-			"eth0"
+			true
 		}
 		Err(NetlinkError(ErrorMessage { code, .. })) if code.abs() == libc::ENODEV => {
 			// This is the expected case that is triggered when the tap device does not exist in the current namespace
-			do_init = true;
-			"eth0"
+			true
 		}
 		Err(err) => {
 			return Err(Box::new(HermitNetworkError::from(format!(
-				"Tap100 interface detection failed: {err}"
+				"Macvtap0 interface detection failed: {err}"
 			))));
 		}
 	};
 
-	let inet_str_output = run_command(
-		"/bin/sh",
-		vec![
-			"-c",
-			if do_init {
-				"echo `ip addr show dev eth0  | grep \"inet\\ \" | awk '{print $2}'`"
-			} else {
-				"echo `ip addr show dev dummy0  | grep \"dummy0:ip\" | awk '{print $2}'`"
-			},
-		],
-	)?;
-	let inet_str = inet_str_output.trim_end_matches('\n');
+	// Get link info for eth0 device
+	let link_info = handle
+		.link()
+		.get()
+		.match_name(String::from("eth0"))
+		.execute()
+		.try_next()
+		.await?
+		.expect("Could not read link info for interface eth0!");
 
-	if inet_str.is_empty() {
-		//warn!("Could not perform network setup! eth0 interface does not exist!");
-		return Err(Box::new(HermitNetworkError::from(format!(
-			"Could not perform network setup! {} interface does not exist!",
-			read_interface
-		))));
+	// Extract device index from link info
+	let eth0_device_index = link_info.header.index;
+
+	//Setup network parameters
+	let mut mac_address: Option<String> = None;
+	let mut ip_address: Option<Ipv4Addr> = None;
+	let mut prefix_length: Option<u8> = None;
+	let mut gateway_address: Option<Ipv4Addr> = None;
+
+	// Get address info for eth0 device
+	let device_addr_msg = handle
+		.address()
+		.get()
+		.set_link_index_filter(eth0_device_index)
+		.execute()
+		.try_next()
+		.await?
+		.expect("Could not read address info for interface eth0!");
+
+	// Extract IP address from address info
+	for nla in device_addr_msg.nlas.iter() {
+		if let address::nlas::Nla::Address(addr) = nla {
+			ip_address = Some(Ipv4Addr::from([addr[0], addr[1], addr[2], addr[3]]));
+			prefix_length = Some(device_addr_msg.header.prefix_len);
+		}
 	}
 
-	let mut inet_str_split = inet_str.split('/');
-
-	let mac_str_output = run_command(
-		"/bin/sh",
-		vec![
-			"-c",
-			format!(
-				"echo `ip addr show dev {}  | grep \"link/ether\\ \" | awk '{{print $2}}'`",
-				read_interface
-			)
-			.as_str(),
-		],
-	)?;
-	let mac_str = mac_str_output.trim_end_matches('\n');
-
-	let ip_addr = inet_str_split.next().unwrap();
-	let cidr = inet_str_split.next().unwrap();
-
-	let gateway_output = run_command(
-		"/bin/sh",
-		vec![
-			"-c",
-			if do_init {
-				r#"echo `ip route | grep ^default | awk '{print $3}'`"#
-			} else {
-				"echo `ip addr show dev dummy0  | grep \"dummy0:gw\" | awk '{print $2}' | awk -F '/' '{print $1}'`"
-			},
-		],
-	)?;
-	let gateway = gateway_output.trim_end_matches('\n');
+	// Get route info and extract gateway address
+	let mut route_get_req = handle.route().get(rtnetlink::IpVersion::V4).execute();
+	while let Some(route_msg) = route_get_req.try_next().await? {
+		for nla in route_msg.nlas.into_iter() {
+			if let route::Nla::Gateway(addr) = nla {
+				gateway_address = Some(Ipv4Addr::from([addr[0], addr[1], addr[2], addr[3]]));
+				break;
+			}
+		}
+	}
 
 	if do_init {
-		let _ = run_command("ip", vec!["tuntap", "add", "tap100", "mode", "tap"]);
-		let _ = run_command("ip", vec!["link", "set", "dev", "tap100", "up"]);
-		let _ = run_command("ip", vec!["addr", "delete", inet_str, "dev", "eth0"]);
-		let _ = run_command(
-			"ip",
-			vec!["link", "set", "eth0", "address", "aa:aa:aa:aa:bb:cc"],
-		); //Random MAC taken from the Nabla code
-		let _ = run_command("ip", vec!["link", "add", "name", "br0", "type", "bridge"]);
-		let _ = run_command("ip", vec!["link", "set", "eth0", "master", "br0"]);
-		let _ = run_command("ip", vec!["link", "set", "tap100", "master", "br0"]);
-		let _ = run_command("ip", vec!["link", "set", "br0", "up"]);
-		// Set up dummy device
-		// This is even uglier: We need to save the addresses we obtained from eth0 somewhere in the network namespace so that
-		// future unikernel instances in the same namespace can access it. This becomes relevant for restarting Kubernetes Pods
-		// because Kubernetes / CRI-O just does spawns a new container on restart in the Pod network namespace without deleting the old one first.
-		let _ = run_command("ip", vec!["link", "add", "dummy0", "type", "dummy"]);
-		let _ = run_command(
-			"ip",
-			vec![
-				"addr",
-				"add",
-				inet_str,
-				"label",
-				"dummy0:ip",
-				"dev",
-				"dummy0",
-			],
-		);
-		let _ = run_command(
-			"ip",
-			vec![
-				"addr",
-				"add",
-				gateway,
-				"label",
-				"dummy0:gw",
-				"dev",
-				"dummy0",
-			],
-		);
-		let _ = run_command("ip", vec!["link", "set", "dummy0", "address", mac_str]);
+		// Create macvtap0 interface
+		handle
+			.link()
+			.add()
+			.macvtap("macvtap0".into(), eth0_device_index, MACVLAN_MODE_PASSTHRU)
+			.execute()
+			.await?;
 	}
+
+	// Determine index of newly created macvtap
+	let macvtap_link_info = handle
+		.link()
+		.get()
+		.match_name("macvtap0".into())
+		.execute()
+		.try_next()
+		.await?
+		.expect("Could not read link info for interface macvtap0!");
+
+	let macvtap_index = macvtap_link_info.header.index;
+
+	// Extract mac from macvtap
+	for nla in macvtap_link_info.nlas.into_iter() {
+		if let link::nlas::Nla::Address(addr) = nla {
+			if addr.len() != 6 {
+				return Err(Box::new(HermitNetworkError::from(format!(
+					"Received invalid MAC address {addr:?} for macvtap device!"
+				))));
+			}
+			mac_address = Some(format!(
+				"{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+				addr[0], addr[1], addr[2], addr[3], addr[4], addr[5]
+			));
+			debug!(
+				"Found macvtap mac address: {}",
+				mac_address.as_ref().unwrap()
+			);
+			break;
+		}
+	}
+
+	// Read tap device numbers associated with macvtap
+	let tap_dev_file_path = PathBuf::from("/sys/class/net/macvtap0/macvtap")
+		.join(format!("tap{}", macvtap_index))
+		.join("dev");
+	let dev_file_string = std::fs::read_to_string(&tap_dev_file_path)
+		.expect(format!("Could not open sysfs entry at {:?}", &tap_dev_file_path).as_str());
+
+	let mut major_minor_split = dev_file_string.split(':');
+
+	let major: u64 = major_minor_split.next().unwrap().trim().parse().unwrap();
+	let minor: u64 = major_minor_split.next().unwrap().trim().parse().unwrap();
+
+	// Create tap device in container
+	let device = nix::sys::stat::makedev(major, minor);
+	nix::sys::stat::mknod(
+		&PathBuf::from(format!("/dev/tap{}", macvtap_index)),
+		SFlag::S_IFCHR,
+		nix::sys::stat::Mode::from_bits(0o600u32).unwrap(),
+		device,
+	)
+	.expect("Could not create tap device corresponding to macvtap0!");
+
+	// Assume all network parameters have been set
+	let ip_address = ip_address.expect("IP address could not be determined during networking setup!");
+	let prefix_length = prefix_length.expect("IP prefix length could not be determined during networking setup!");
+	let gateway_address = gateway_address.expect("Gateway address could not be determined during networking setup!");
+	let mac_address = mac_address.expect("MAC address could not be determined during networking setup!");
 
 	info!(
 		"Found / created network setup: IP={},MASK={},GW={},MAC={}",
-		ip_addr, cidr, gateway, mac_str
+		ip_address.to_string(),
+		prefix_length,
+		gateway_address.to_string(),
+		&mac_address
 	);
 
-	let cidr_int: u32 = cidr.parse().unwrap();
-	let mask: Ipv4Addr = Ipv4Addr::from(0xffffffffu32 << cidr_int);
+	let mask: Ipv4Addr = Ipv4Addr::from(0xffffffffu32 << prefix_length);
 	Ok(HermitNetworkConfig {
-		ip: ip_addr.parse().unwrap(),
-		gateway: gateway.parse().unwrap(),
+		ip: ip_address,
+		gateway: gateway_address,
 		mask,
-		mac: mac_address.unwrap(),
-		macvtap_index: macvtap_index.unwrap()
+		mac: mac_address,
+		macvtap_index,
 	})
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -180,7 +180,7 @@ pub async fn create_tap() -> Result<HermitNetworkConfig, Box<dyn std::error::Err
 		.join(format!("tap{}", macvtap_index))
 		.join("dev");
 	let dev_file_string = std::fs::read_to_string(&tap_dev_file_path)
-		.expect(format!("Could not open sysfs entry at {:?}", &tap_dev_file_path).as_str());
+		.unwrap_or_else(|_| panic!("Could not open sysfs entry at {:?}", &tap_dev_file_path));
 
 	let mut major_minor_split = dev_file_string.split(':');
 
@@ -198,10 +198,14 @@ pub async fn create_tap() -> Result<HermitNetworkConfig, Box<dyn std::error::Err
 	.expect("Could not create tap device corresponding to macvtap0!");
 
 	// Assume all network parameters have been set
-	let ip_address = ip_address.expect("IP address could not be determined during networking setup!");
-	let prefix_length = prefix_length.expect("IP prefix length could not be determined during networking setup!");
-	let gateway_address = gateway_address.expect("Gateway address could not be determined during networking setup!");
-	let mac_address = mac_address.expect("MAC address could not be determined during networking setup!");
+	let ip_address =
+		ip_address.expect("IP address could not be determined during networking setup!");
+	let prefix_length =
+		prefix_length.expect("IP prefix length could not be determined during networking setup!");
+	let gateway_address =
+		gateway_address.expect("Gateway address could not be determined during networking setup!");
+	let mac_address =
+		mac_address.expect("MAC address could not be determined during networking setup!");
 
 	info!(
 		"Found / created network setup: IP={},MASK={},GW={},MAC={}",


### PR DESCRIPTION
This PR replaces the previous container networking setup, which created a bridge between the veth interface inside the container and a tap device using the `ip` command, by a new setup configuring a macvtap interface. The macvtap is created using the rtnetlink crate which removes the dependency on the `iproute` commands. Compared to the previous setup, using a macvtap requires less setup steps and should provide better networking performance.