### PR TITLE
add support of Qemu's user network

### DIFF
--- a/src/hermit.rs
+++ b/src/hermit.rs
@@ -38,7 +38,7 @@ pub fn prepare_environment(project_dir: &Path, hermit_env_path: &Option<PathBuf>
 }
 
 pub enum NetworkConfig {
-	VirtIO(network::VirtioNetworkConfig),
+	TapNetwork(network::VirtioNetworkConfig),
 	UserNetwork(u16),
 	None,
 }
@@ -109,7 +109,7 @@ pub fn get_qemu_args(
 	}
 
 	let mut args_string = match netconf {
-		NetworkConfig::VirtIO(network_config) => {
+		NetworkConfig::TapNetwork(network_config) => {
 			exec_args.push("-netdev".to_string());
 			exec_args.push(format!("tap,id=net0,fd={}", tap_fd.unwrap()));
 			exec_args.push("-device".to_string());
@@ -137,7 +137,7 @@ pub fn get_qemu_args(
 				user_port, user_port
 			));
 			exec_args.push("-device".to_string());
-			exec_args.push("rtl8139,netdev=u1".to_string());
+			exec_args.push("virtio-net-pci,netdev=u1,disable-legacy=on".to_string());
 			exec_args.push("-append".to_string());
 
 			"".to_string()

--- a/src/hermit.rs
+++ b/src/hermit.rs
@@ -44,6 +44,7 @@ pub fn get_qemu_args(
 	app_args: &[String],
 	micro_vm: bool,
 	kvm: bool,
+	user_port: u32,
 	tap_fd: &Option<i32>,
 ) -> Vec<String> {
 	let mut exec_args: Vec<String> = vec![
@@ -114,6 +115,14 @@ pub fn get_qemu_args(
 				network_config.mac
 			)
 		});
+	} else if user_port > 0 {
+		exec_args.push("-netdev".to_string());
+		exec_args.push(format!(
+			"user,id=u1,hostfwd=tcp::{}-:{},net=192.168.76.0/24,dhcpstart=192.168.76.9",
+			user_port, user_port
+		));
+		exec_args.push("-device".to_string());
+		exec_args.push("rtl8139,netdev=u1".to_string());
 	}
 
 	exec_args.push("-append".to_string());

--- a/src/init.rs
+++ b/src/init.rs
@@ -400,7 +400,7 @@ fn init_stage_child(args: SetupArgs) -> ! {
 
 	let hermit_network_config = if args.config.is_hermit_container && user_port == 0 {
 		match tokio_runtime.block_on(network::create_tap()) {
-			Ok(config) => NetworkConfig::VirtIO(config),
+			Ok(config) => NetworkConfig::TapNetwork(config),
 			Err(err) => {
 				warn!("Hermit network setup could not be completed: {err}");
 				NetworkConfig::None
@@ -535,7 +535,7 @@ fn init_stage_child(args: SetupArgs) -> ! {
 			.parse()
 			.expect("RUNH_MICRO_VM was not an unsigned integer!");
 
-		tap_fd = if let NetworkConfig::VirtIO(ref netconf) = hermit_network_config {
+		tap_fd = if let NetworkConfig::TapNetwork(ref netconf) = hermit_network_config {
 			let tap_file = OpenOptions::new()
 				.read(true)
 				.write(true)

--- a/src/init.rs
+++ b/src/init.rs
@@ -392,7 +392,12 @@ fn init_stage_child(args: SetupArgs) -> ! {
 		nix::unistd::chdir("/").expect("Could not chdir to / after chroot!");
 	}
 
-	let hermit_network_config = if args.config.is_hermit_container {
+	let user_port: u32 = env::var("RUNH_USER_PORT")
+		.unwrap_or_else(|_| "0".to_string())
+		.parse()
+		.expect("RUNH_USER_PORT was not an unsigned integer!");
+
+	let hermit_network_config = if args.config.is_hermit_container && user_port == 0 {
 		match tokio_runtime.block_on(network::create_tap()) {
 			Ok(config) => Some(config),
 			Err(err) => {
@@ -550,6 +555,7 @@ fn init_stage_child(args: SetupArgs) -> ! {
 				.unwrap(),
 			micro_vm > 0,
 			kvm > 0,
+			user_port,
 			&tap_fd,
 		)
 	} else {

--- a/src/init.rs
+++ b/src/init.rs
@@ -9,6 +9,7 @@ use std::{
 	os::unix::prelude::{FromRawFd, RawFd},
 };
 
+use crate::hermit::NetworkConfig;
 use crate::{console, devices, hermit, mounts};
 use crate::{flags, paths, rootfs};
 use crate::{namespaces, network};
@@ -392,21 +393,23 @@ fn init_stage_child(args: SetupArgs) -> ! {
 		nix::unistd::chdir("/").expect("Could not chdir to / after chroot!");
 	}
 
-	let user_port: u32 = env::var("RUNH_USER_PORT")
+	let user_port: u16 = env::var("RUNH_USER_PORT")
 		.unwrap_or_else(|_| "0".to_string())
 		.parse()
 		.expect("RUNH_USER_PORT was not an unsigned integer!");
 
 	let hermit_network_config = if args.config.is_hermit_container && user_port == 0 {
 		match tokio_runtime.block_on(network::create_tap()) {
-			Ok(config) => Some(config),
+			Ok(config) => NetworkConfig::VirtIO(config),
 			Err(err) => {
 				warn!("Hermit network setup could not be completed: {err}");
-				None
+				NetworkConfig::None
 			}
 		}
+	} else if args.config.is_hermit_container && user_port > 0 {
+		NetworkConfig::UserNetwork(user_port)
 	} else {
-		None
+		NetworkConfig::None
 	};
 
 	//TODO: re-open /dev/null in the container if any std-fd points to it
@@ -532,14 +535,16 @@ fn init_stage_child(args: SetupArgs) -> ! {
 			.parse()
 			.expect("RUNH_MICRO_VM was not an unsigned integer!");
 
-		tap_fd = hermit_network_config.as_ref().map(|conf| {
+		tap_fd = if let NetworkConfig::VirtIO(ref netconf) = hermit_network_config {
 			let tap_file = OpenOptions::new()
 				.read(true)
 				.write(true)
-				.open(format!("/dev/tap{}", conf.macvtap_index))
+				.open(format!("/dev/tap{}", netconf.macvtap_index))
 				.expect("Could not open tap device file!");
-			tap_file.into_raw_fd()
-		});
+			Some(tap_file.into_raw_fd())
+		} else {
+			None
+		};
 
 		hermit::get_qemu_args(
 			kernel,
@@ -555,7 +560,6 @@ fn init_stage_child(args: SetupArgs) -> ! {
 				.unwrap(),
 			micro_vm > 0,
 			kvm > 0,
-			user_port,
 			&tap_fd,
 		)
 	} else {


### PR DESCRIPTION
By setting the environment variable RUN_USER_PORT, the VM will use Qemu's user network and listen on the port RUN_USER_PORT.