### PR TITLE
switch to Clap 4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,15 +18,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,17 +42,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -140,18 +120,40 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "4ec7a4128863c188deefe750ac1d1dfe66c236909f845af04beed823638dc1b2"
 dependencies = [
- "ansi_term",
- "atty",
  "bitflags",
- "strsim 0.8.0",
- "term_size",
- "textwrap",
- "unicode-width",
- "vec_map",
+ "clap_derive",
+ "clap_lex",
+ "is-terminal",
+ "once_cell",
+ "strsim",
+ "termcolor",
+ "terminal_size",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -262,7 +264,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
+ "strsim",
  "syn",
 ]
 
@@ -584,13 +586,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.1.19"
+name = "heck"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -728,6 +727,18 @@ name = "ipnet"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+dependencies = [
+ "hermit-abi",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys",
+]
 
 [[package]]
 name = "itoa"
@@ -991,7 +1002,7 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi",
  "libc",
 ]
 
@@ -1058,6 +1069,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "parking_lot"
@@ -1543,12 +1560,6 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
@@ -1565,7 +1576,7 @@ version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -1609,23 +1620,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "term_size"
-version = "0.3.2"
+name = "termcolor"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
- "libc",
- "winapi",
+ "winapi-util",
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.11.0"
+name = "terminal_size"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+checksum = "cb20089a8ba2b69debd491f8d2d023761cbf196e999218c591fa1e7e15a21907"
 dependencies = [
- "term_size",
- "unicode-width",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1811,12 +1821,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
 name = "url"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1832,12 +1836,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -1965,6 +1963,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ description = "runh is a CLI tool for spawning and running RustyHermit container
 
 [dependencies]
 capctl = "0.2"
-clap = { version = "2.33", features = ["wrap_help", "suggestions"] }
+clap = { version = "4.1", features = ["wrap_help", "derive", "color", "cargo", "suggestions"] }
 colour = "0.6"
 command-fds = "0.2"
 dkregistry = { git = "https://github.com/camallo/dkregistry-rs.git" }

--- a/src/delete.rs
+++ b/src/delete.rs
@@ -26,20 +26,20 @@ use std::path::PathBuf;
 // 	Ok(())
 // }
 
-pub fn delete_container(project_dir: PathBuf, id: Option<&str>, force: bool) {
-	if let Some(container_state) = state::get_container_state(project_dir.clone(), id.unwrap()) {
+pub fn delete_container(project_dir: PathBuf, id: &str, force: bool) {
+	if let Some(container_state) = state::get_container_state(project_dir.clone(), id) {
 		if container_state.status != "stopped" {
 			if !force {
 				panic!("Tried to delete a container that is not stopped!");
 			} else if container_state.status != "creating" {
 				warn!("Container is still running. Force-deleting...");
-				kill::kill_container(project_dir.clone(), id, Some("SIGKILL"), false);
+				kill::kill_container(project_dir.clone(), id, "SIGKILL", false);
 			} else {
 				warn!("Container has not finished creation. Force-deleting...");
 			}
 		}
 
-		let container_dir = project_dir.join(id.unwrap());
+		let container_dir = project_dir.join(id);
 
 		let rootfs_overlay_dir = container_dir.join("rootfs/merged");
 		if rootfs_overlay_dir.exists() {
@@ -59,9 +59,6 @@ pub fn delete_container(project_dir: PathBuf, id: Option<&str>, force: bool) {
 	//Additionally to deleting all the files, we should also delete all remaining processes spawned by the container init process.
 	//However, without cgroup support there is currently no real way to do this as we do not know when (and how) the init process will be killed
 	} else {
-		warn!(
-			"Container `{}` doesn't exists! Skipping deletion...",
-			id.unwrap()
-		);
+		warn!("Container `{id}` doesn't exists! Skipping deletion...");
 	}
 }

--- a/src/hermit.rs
+++ b/src/hermit.rs
@@ -18,14 +18,14 @@ pub fn create_environment(_path: &Path) {
 	//TODO
 }
 
-pub fn get_environment_path(project_dir: &Path, hermit_env_path: &Option<&str>) -> PathBuf {
+pub fn get_environment_path(project_dir: &Path, hermit_env_path: &Option<PathBuf>) -> PathBuf {
 	match hermit_env_path {
-		Some(s) => PathBuf::from(s),
+		Some(s) => s.clone(),
 		None => project_dir.join("hermit"),
 	}
 }
 
-pub fn prepare_environment(project_dir: &Path, hermit_env_path: &Option<&str>) {
+pub fn prepare_environment(project_dir: &Path, hermit_env_path: &Option<PathBuf>) {
 	let environment_path = get_environment_path(project_dir, hermit_env_path);
 	if !environment_path.exists() {
 		create_environment(&environment_path);

--- a/src/kill.rs
+++ b/src/kill.rs
@@ -3,9 +3,9 @@ use std::{convert::TryFrom, path::PathBuf, str::FromStr};
 
 use crate::state;
 
-pub fn kill_container(project_dir: PathBuf, id: Option<&str>, sig: Option<&str>, all: bool) {
-	let container_state = state::get_container_state(project_dir, id.unwrap())
-		.unwrap_or_else(|| panic!("Could not query state for container {}", id.unwrap()));
+pub fn kill_container(project_dir: PathBuf, id: &str, sig: &str, all: bool) {
+	let container_state = state::get_container_state(project_dir, id)
+		.unwrap_or_else(|| panic!("Could not query state for container {}", id));
 	if container_state.status != "created" && container_state.status != "running" {
 		panic!("Cannot send signals to non-running containers!")
 	}
@@ -15,24 +15,23 @@ pub fn kill_container(project_dir: PathBuf, id: Option<&str>, sig: Option<&str>,
 	}
 
 	let pid = container_state.pid.unwrap();
-	let signal = if let Ok(sig_nr) = sig.unwrap().parse::<i32>() {
+	let signal = if let Ok(sig_nr) = sig.parse::<i32>() {
 		nix::sys::signal::Signal::try_from(sig_nr)
-			.unwrap_or_else(|_| panic!("Could not parse signal number {}", sig.unwrap()))
+			.unwrap_or_else(|_| panic!("Could not parse signal number {}", sig))
 	} else {
-		let signal_str = if !sig.unwrap().starts_with("SIG") {
-			format!("SIG{}", sig.unwrap())
+		let signal_str = if !sig.starts_with("SIG") {
+			format!("SIG{}", sig)
 		} else {
-			sig.unwrap().to_owned()
+			sig.to_owned()
 		};
 		nix::sys::signal::Signal::from_str(signal_str.as_str())
-			.unwrap_or_else(|_| panic!("Could not parse signal string {}", sig.unwrap()))
+			.unwrap_or_else(|_| panic!("Could not parse signal string {}", sig))
 	};
 
 	nix::sys::signal::kill(Pid::from_raw(pid), signal).unwrap_or_else(|_| {
 		panic!(
 			"Could not send signal {} to container process ID  {}!",
-			sig.unwrap(),
-			pid
+			sig, pid
 		)
 	});
 }

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -1,11 +1,8 @@
 use oci_spec::runtime;
-use std::fs;
 use std::path;
 
-pub fn create_spec(bundle: Option<&str>, args: Vec<String>) {
-	let dir = fs::canonicalize(path::PathBuf::from(bundle.unwrap()))
-		.expect("Unable to determine absolute bundle path");
-	let mut config_file = dir;
+pub fn create_spec(bundle: path::PathBuf, args: Vec<String>) {
+	let mut config_file = bundle;
 	config_file.push("config.json");
 	let spec: runtime::Spec = runtime::SpecBuilder::default()
 		.process(

--- a/src/start.rs
+++ b/src/start.rs
@@ -3,8 +3,8 @@ use std::fs::{self, File};
 use std::io::Read;
 use std::path::PathBuf;
 
-pub fn start_container(mut project_dir: PathBuf, id: Option<&str>) {
-	project_dir.push(id.unwrap());
+pub fn start_container(mut project_dir: PathBuf, id: &str) {
+	project_dir.push(id);
 
 	if let Ok(mut file) = fs::OpenOptions::new()
 		.read(true)
@@ -44,6 +44,6 @@ pub fn start_container(mut project_dir: PathBuf, id: Option<&str>) {
 			}
 		}
 	} else {
-		println!("Container `{}` doesn't exists", id.unwrap());
+		println!("Container `{}` doesn't exists", id);
 	}
 }


### PR DESCRIPTION
The old clap version uses unmaintained crates. This PR should close issue #73, #100, and #110.