### PR TITLE
Delete bors.toml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,12 +7,8 @@ updates:
     schedule:
       interval: "weekly"
       timezone: "Europe/Berlin"
-    # Automatic rebases cancel pending bors merges
-    rebase-strategy: "disabled"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
       timezone: "Europe/Berlin"
-    # Automatic rebases cancel pending bors merges
-    rebase-strategy: "disabled"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,8 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
-      - staging
-      - trying
   pull_request:
-  schedule:
-    - cron: '0 0 * * 6'
+  merge_group:
 
 jobs:
   clippy:

--- a/bors.toml
+++ b/bors.toml
@@ -1,7 +1,0 @@
-status = [
-  "Setup, build and test",
-  "Format check",
-  "Clippy",
-]
-delete_merged_branches = true
-timeout_sec = 3600


### PR DESCRIPTION
bors-ng is now [deprecated]. We should migrate to [built-in merge queues].

[deprecated]: https://bors.tech/newsletter/2023/05/01/tmib-76/
[built-in merge queues]: https://github.blog/changelog/2023-02-08-pull-request-merge-queue-public-beta/