### PR TITLE
Add support for time isolation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,9 +656,9 @@ dependencies = [
 
 [[package]]
 name = "oci-spec"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "214b837f7dde5026f2028ead5ae720073277c19f82ff85623b142c39d4b843e7"
+checksum = "cf77d2eace1f4909b081d231d1ad3570ba3448ae95290ab701314faaee1b611a"
 dependencies = [
  "derive_builder",
  "getset",

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -1,3 +1,5 @@
+use std::ffi::c_int;
+
 use nix::sched::CloneFlags;
 use oci_spec::runtime;
 
@@ -20,5 +22,11 @@ pub fn get_cloneflag(typ: runtime::LinuxNamespaceType) -> CloneFlags {
 		runtime::LinuxNamespaceType::Pid => CloneFlags::CLONE_NEWPID,
 		runtime::LinuxNamespaceType::User => CloneFlags::CLONE_NEWUSER,
 		runtime::LinuxNamespaceType::Uts => CloneFlags::CLONE_NEWUTS,
+		runtime::LinuxNamespaceType::Time => {
+			// TODO: This is missing from both libc and nix.
+			// https://github.com/rust-lang/libc/issues/3033
+			const CLONE_NEWTIME: c_int = 0x80;
+			unsafe { CloneFlags::from_bits_unchecked(CLONE_NEWTIME) }
+		}
 	}
 }


### PR DESCRIPTION
Upgrades oci_spec from 0.6.0 to 0.6.1.

Closes https://github.com/hermitcore/runh/pull/217.